### PR TITLE
Django 3 support

### DIFF
--- a/django_enum/fields.py
+++ b/django_enum/fields.py
@@ -69,7 +69,7 @@ class EnumField(CustomTypeField):
             kwargs['case_sensitive'] = self.case_sensitive
         return name, path, args, kwargs
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, *args):
         if value is None:
             return None
         with suppress(KeyError):

--- a/django_more/fields/hashfield.py
+++ b/django_more/fields/hashfield.py
@@ -33,7 +33,7 @@ class HashField(models.CharField):
             del kwargs["max_length"]
         return name, path, args, kwargs
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, *args):
         if value is None:
             return None
         return HashString.from_b64(value)


### PR DESCRIPTION
`context` parameter has been deprecated in Django 3.
Since we're only using `value`, the rest is hidden under `*args`